### PR TITLE
feat: add resizable query editor and results with drag handle

### DIFF
--- a/src/components/ResizablePanels.tsx
+++ b/src/components/ResizablePanels.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface ResizablePanelsProps {
+  topPanel: React.ReactNode;
+  bottomPanel: React.ReactNode;
+  initialTopHeight?: number;
+  minTopHeight?: number;
+  maxTopHeight?: number;
+  onHeightChange?: (height: number) => void;
+  className?: string;
+}
+
+export function ResizablePanels({
+  topPanel,
+  bottomPanel,
+  initialTopHeight = 50, // Percentage
+  minTopHeight = 20,
+  maxTopHeight = 80,
+  onHeightChange,
+  className = "",
+}: ResizablePanelsProps) {
+  const [topHeight, setTopHeight] = useState(initialTopHeight);
+  const [isDragging, setIsDragging] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const startY = useRef(0);
+  const startHeight = useRef(0);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      setIsDragging(true);
+      startY.current = e.clientY;
+      startHeight.current = topHeight;
+    },
+    [topHeight],
+  );
+
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (!isDragging || !containerRef.current) return;
+
+      const container = containerRef.current;
+      const containerRect = container.getBoundingClientRect();
+      const deltaY = e.clientY - startY.current;
+      const deltaPercentage = (deltaY / containerRect.height) * 100;
+
+      let newHeight = startHeight.current + deltaPercentage;
+      newHeight = Math.max(minTopHeight, Math.min(maxTopHeight, newHeight));
+
+      setTopHeight(newHeight);
+      onHeightChange?.(newHeight);
+    },
+    [isDragging, minTopHeight, maxTopHeight, onHeightChange],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  useEffect(() => {
+    if (isDragging) {
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+      document.body.style.cursor = "row-resize";
+      document.body.style.userSelect = "none";
+
+      return () => {
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+      };
+    }
+  }, [isDragging, handleMouseMove, handleMouseUp]);
+
+  return (
+    <div ref={containerRef} className={`flex flex-col h-full ${className}`}>
+      {/* Top Panel */}
+      <div style={{ height: `${topHeight}%` }} className="min-h-0">
+        {topPanel}
+      </div>
+
+      {/* Resizable Divider */}
+      <div
+        className={`
+          h-1 bg-border cursor-row-resize hover:bg-border/80 transition-colors
+          relative group
+          ${isDragging ? "bg-primary" : ""}
+        `}
+        onMouseDown={handleMouseDown}
+      >
+        {/* Invisible expanded hit area for easier dragging */}
+        <div className="absolute inset-x-0 -top-1 -bottom-1 w-full" />
+
+        {/* Visual indicator on hover */}
+        <div className="absolute inset-x-0 top-0 w-full h-full bg-primary/20 opacity-0 group-hover:opacity-100 transition-opacity" />
+      </div>
+
+      {/* Bottom Panel */}
+      <div style={{ height: `${100 - topHeight}%` }} className="min-h-0">
+        {bottomPanel}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SQLQueryWorkspace.tsx
+++ b/src/components/SQLQueryWorkspace.tsx
@@ -5,6 +5,7 @@ import { executeCustomSQLQuery } from "@/lib/actions";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { QueryResults } from "./QueryResults";
+import { ResizablePanels } from "./ResizablePanels";
 import { SQLEditor } from "./SQLEditor";
 
 interface SQLQueryWorkspaceProps {
@@ -63,6 +64,17 @@ export function SQLQueryWorkspace({
       // Auto-save to localStorage if there's an active query
       if (queryId) {
         updateQuery(queryId, { query });
+      }
+    },
+    [queryId, updateQuery],
+  );
+
+  // Handle editor height changes
+  const handleHeightChange = useCallback(
+    (height: number) => {
+      // Auto-save height to localStorage if there's an active query
+      if (queryId) {
+        updateQuery(queryId, { editorHeight: height });
       }
     },
     [queryId, updateQuery],
@@ -164,30 +176,33 @@ export function SQLQueryWorkspace({
 
   return (
     <div className="flex flex-col h-full">
-      {/* Main content area with editor and results */}
-      <div className="flex-1 flex flex-col min-h-0">
-        {/* SQL Editor - takes up half the available space */}
-        <div className="h-1/2 border-b">
-          <SQLEditor
-            query={currentQuery}
-            onQueryChange={handleQueryChange}
-            onExecute={handleExecuteQuery}
-            isExecuting={execution.isLoading}
-          />
-        </div>
-
-        {/* Query Results - takes up the other half */}
-        <div className="h-1/2">
-          <QueryResults
-            results={execution.results}
-            columns={execution.columns}
-            isLoading={execution.isLoading}
-            error={execution.error}
-            message={execution.message}
-            rowCount={execution.rowCount}
-            onRefresh={() => handleExecuteQuery(currentQuery)}
-          />
-        </div>
+      {/* Main content area with resizable editor and results */}
+      <div className="flex-1 min-h-0">
+        <ResizablePanels
+          initialTopHeight={activeQuery?.editorHeight ?? 50}
+          minTopHeight={20}
+          maxTopHeight={80}
+          onHeightChange={handleHeightChange}
+          topPanel={
+            <SQLEditor
+              query={currentQuery}
+              onQueryChange={handleQueryChange}
+              onExecute={handleExecuteQuery}
+              isExecuting={execution.isLoading}
+            />
+          }
+          bottomPanel={
+            <QueryResults
+              results={execution.results}
+              columns={execution.columns}
+              isLoading={execution.isLoading}
+              error={execution.error}
+              message={execution.message}
+              rowCount={execution.rowCount}
+              onRefresh={() => handleExecuteQuery(currentQuery)}
+            />
+          }
+        />
       </div>
     </div>
   );

--- a/src/components/TableDataGrid.tsx
+++ b/src/components/TableDataGrid.tsx
@@ -448,21 +448,34 @@ export function TableDataGrid({
                 onValueChange={(v) => onPageSizeChange(Number(v))}
               >
                 <SelectTrigger size="sm">
-                  <SelectValue>Showing {Math.min(pageSize, pagination.total)} / {pagination.total} rows</SelectValue>
+                  <SelectValue>
+                    Showing {Math.min(pageSize, pagination.total)} /{" "}
+                    {pagination.total} rows
+                  </SelectValue>
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="20">Show {Math.min(pagination.total, 20)}</SelectItem>
+                  <SelectItem value="20">
+                    Show {Math.min(pagination.total, 20)}
+                  </SelectItem>
                   {pagination.total > 20 && (
-                    <SelectItem value="50">Show {Math.min(pagination.total, 50)}</SelectItem>
+                    <SelectItem value="50">
+                      Show {Math.min(pagination.total, 50)}
+                    </SelectItem>
                   )}
                   {pagination.total > 50 && (
-                    <SelectItem value="100">Show {Math.min(pagination.total, 100)}</SelectItem>
+                    <SelectItem value="100">
+                      Show {Math.min(pagination.total, 100)}
+                    </SelectItem>
                   )}
                   {pagination.total > 100 && (
-                    <SelectItem value="250">Show {Math.min(pagination.total, 250)}</SelectItem>
+                    <SelectItem value="250">
+                      Show {Math.min(pagination.total, 250)}
+                    </SelectItem>
                   )}
                   {pagination.total > 250 && (
-                    <SelectItem value="500">Show {Math.min(pagination.total, 500)}</SelectItem>
+                    <SelectItem value="500">
+                      Show {Math.min(pagination.total, 500)}
+                    </SelectItem>
                   )}
                 </SelectContent>
               </Select>

--- a/src/hooks/useCustomQueries.ts
+++ b/src/hooks/useCustomQueries.ts
@@ -8,6 +8,7 @@ export interface CustomQuery {
   query: string;
   createdAt: Date;
   lastModified: Date;
+  editorHeight?: number; // Height percentage for the query editor (0-100)
 }
 
 interface UseCustomQueriesOptions {
@@ -91,7 +92,10 @@ export function useCustomQueries({
 
   // Update an existing query
   const updateQuery = useCallback(
-    (id: string, updates: Partial<Pick<CustomQuery, "name" | "query">>) => {
+    (
+      id: string,
+      updates: Partial<Pick<CustomQuery, "name" | "query" | "editorHeight">>,
+    ) => {
       const newQueries = queries.map((q) =>
         q.id === id ? { ...q, ...updates, lastModified: new Date() } : q,
       );


### PR DESCRIPTION
Add a drag handle to the horizontal divider between the query editor and query results on the query page such that the user can resize the height of the query editor and have that height persisted along with the query in local storage.

## Changes
- Add ResizablePanels component with smooth drag functionality
- Extend CustomQuery interface to store editor height
- Implement height persistence in localStorage
- Add visual feedback on hover and drag states
- Set height constraints between 20%-80% for editor section

Fixes #28

Generated with [Claude Code](https://claude.ai/code)